### PR TITLE
Add basic experience and leveling system

### DIFF
--- a/src/engine/components/Experience.js
+++ b/src/engine/components/Experience.js
@@ -1,0 +1,7 @@
+export class Experience {
+  constructor(level = 1, xp = 0, nextLevelXp = 5) {
+    this.level = level;
+    this.xp = xp;
+    this.nextLevelXp = nextLevelXp;
+  }
+}

--- a/src/engine/components/XPGem.js
+++ b/src/engine/components/XPGem.js
@@ -1,0 +1,5 @@
+export class XPGem {
+  constructor(value = 1) {
+    this.value = value;
+  }
+}

--- a/src/engine/systems/CollisionSystem.js
+++ b/src/engine/systems/CollisionSystem.js
@@ -3,6 +3,8 @@ import { Sprite } from '../components/Sprite.js';
 import { Bullet } from '../components/Bullet.js';
 import { Enemy } from '../components/Enemy.js';
 import { PlayerControlled } from '../components/PlayerControlled.js';
+import { XPGem } from '../components/XPGem.js';
+import { Entity } from '../Entity.js';
 
 export class CollisionSystem {
   update() {
@@ -18,6 +20,11 @@ export class CollisionSystem {
         if (dist < bs.size / 2 + es.size / 2) {
           this.game.removeEntity(bullet);
           this.game.removeEntity(enemy);
+          const gem = new Entity()
+            .add(new Position(ep.x, ep.y))
+            .add(new Sprite(6, 'green'))
+            .add(new XPGem());
+          this.game.addEntity(gem);
           break;
         }
       }

--- a/src/engine/systems/PickupSystem.js
+++ b/src/engine/systems/PickupSystem.js
@@ -1,0 +1,32 @@
+import { Position } from '../components/Position.js';
+import { Sprite } from '../components/Sprite.js';
+import { XPGem } from '../components/XPGem.js';
+import { Experience } from '../components/Experience.js';
+import { PlayerControlled } from '../components/PlayerControlled.js';
+
+export class PickupSystem {
+  update() {
+    const entities = Array.from(this.game.entities);
+    const player = entities.find(e => e.has(PlayerControlled) && e.has(Position) && e.has(Experience));
+    if (!player) return;
+    const pp = player.get(Position);
+    const ps = player.get(Sprite);
+    const exp = player.get(Experience);
+
+    for (const gem of entities.filter(e => e.has(XPGem) && e.has(Position))) {
+      const gp = gem.get(Position);
+      const gs = gem.get(Sprite);
+      const dist = Math.hypot(pp.x - gp.x, pp.y - gp.y);
+      if (dist < ps.size / 2 + gs.size / 2) {
+        exp.xp += gem.get(XPGem).value;
+        while (exp.xp >= exp.nextLevelXp) {
+          exp.xp -= exp.nextLevelXp;
+          exp.level++;
+          exp.nextLevelXp = Math.floor(exp.nextLevelXp * 1.5);
+          console.log(`Level Up! Level ${exp.level}`);
+        }
+        this.game.removeEntity(gem);
+      }
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,14 @@ import { Position } from './engine/components/Position.js';
 import { Velocity } from './engine/components/Velocity.js';
 import { Sprite } from './engine/components/Sprite.js';
 import { PlayerControlled } from './engine/components/PlayerControlled.js';
+import { Experience } from './engine/components/Experience.js';
 import { MovementSystem } from './engine/systems/MovementSystem.js';
 import { RenderSystem } from './engine/systems/RenderSystem.js';
 import { PlayerControlSystem } from './engine/systems/PlayerControlSystem.js';
 import { BulletSystem } from './engine/systems/BulletSystem.js';
 import { EnemySpawnerSystem } from './engine/systems/EnemySpawnerSystem.js';
 import { CollisionSystem } from './engine/systems/CollisionSystem.js';
+import { PickupSystem } from './engine/systems/PickupSystem.js';
 import { Input } from './input.js';
 
 const canvas = document.getElementById('game');
@@ -23,6 +25,7 @@ game.addSystem(new MovementSystem());
 game.addSystem(new BulletSystem());
 game.addSystem(new EnemySpawnerSystem());
 game.addSystem(new PlayerControlSystem(input));
+game.addSystem(new PickupSystem());
 game.addSystem(new CollisionSystem());
 game.addSystem(new RenderSystem());
 
@@ -30,7 +33,8 @@ const player = new Entity()
   .add(new Position(canvas.width / 2, canvas.height / 2))
   .add(new Velocity())
   .add(new Sprite(20, 'cyan'))
-  .add(new PlayerControlled());
+  .add(new PlayerControlled())
+  .add(new Experience());
 
 game.addEntity(player);
 

--- a/tests/experience.test.js
+++ b/tests/experience.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Game } from '../src/engine/Game.js';
+import { Entity } from '../src/engine/Entity.js';
+import { Position } from '../src/engine/components/Position.js';
+import { Sprite } from '../src/engine/components/Sprite.js';
+import { Experience } from '../src/engine/components/Experience.js';
+import { PlayerControlled } from '../src/engine/components/PlayerControlled.js';
+import { XPGem } from '../src/engine/components/XPGem.js';
+import { PickupSystem } from '../src/engine/systems/PickupSystem.js';
+
+const mockCtx = {
+  canvas: { width: 800, height: 600 },
+  clearRect() {},
+  fillRect() {}
+};
+
+test('Player collects XP gem and levels up', () => {
+  const game = new Game(mockCtx);
+  const pickup = new PickupSystem();
+  game.addSystem(pickup);
+  const player = new Entity()
+    .add(new Position(0, 0))
+    .add(new Sprite(20))
+    .add(new Experience(1, 4, 5))
+    .add(new PlayerControlled());
+  const gem = new Entity()
+    .add(new Position(5, 0))
+    .add(new Sprite(5))
+    .add(new XPGem(1));
+  game.addEntity(player);
+  game.addEntity(gem);
+  pickup.update();
+  const exp = player.get(Experience);
+  assert.equal(exp.level, 2);
+  assert.equal(exp.xp, 0);
+  assert.ok(!game.entities.has(gem));
+});


### PR DESCRIPTION
## Summary
- spawn green XP gems from defeated enemies
- let the player collect gems, gain experience, and level up
- cover XP gem collection with a new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab652d874883328fd5b9e518cf9153