### PR TITLE
Add timed stages, scaled emoji enemies, and fullscreen HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <title>The Game</title>
   <style>
     body { margin: 0; background: #111; }
-    canvas { display: block; margin: 0 auto; background: #222; }
-    #hud { position: absolute; top: 10px; left: 10px; width: 780px; }
+    canvas { display: block; margin: 0 auto; background: #222; width: 100vw; height: 100vh; }
+    #hud { position: absolute; bottom: 0; left: 0; width: 100%; }
     .bar { height: 10px; background: #444; margin-bottom: 5px; }
     .fill { height: 100%; width: 100%; background: green; }
     #xp-fill { background: blue; }
@@ -20,15 +20,22 @@
 <body>
   <div id="start-menu" class="overlay">
     <h1>The Game</h1>
+    <div id="coins">Coins: 0</div>
+    <label>Stage:
+      <select id="stage-select">
+        <option value="15">15 min</option>
+        <option value="20">20 min</option>
+        <option value="30">30 min</option>
+      </select>
+    </label>
     <button id="start-btn">Start</button>
   </div>
   <div id="level-menu" class="overlay hidden"></div>
   <div id="hud">
-    <div class="bar"><div id="health-fill" class="fill"></div></div>
     <div class="bar"><div id="xp-fill" class="fill"></div></div>
     <div id="stats"></div>
   </div>
-  <canvas id="game" width="800" height="600"></canvas>
+  <canvas id="game"></canvas>
   <script type="module" src="./src/index.js"></script>
 </body>
 </html>

--- a/src/engine/Game.js
+++ b/src/engine/Game.js
@@ -5,6 +5,7 @@ export class Game {
     this.systems = [];
     this.lastTime = 0;
     this.running = false;
+    this.elapsed = 0;
   }
   addEntity(entity) {
     this.entities.add(entity);
@@ -25,6 +26,7 @@ export class Game {
     if (!this.running) return;
     const dt = (time - this.lastTime) / 1000;
     this.lastTime = time;
+    this.elapsed += dt;
     for (const system of this.systems) {
       system.update(dt);
     }

--- a/src/engine/components/Enemy.js
+++ b/src/engine/components/Enemy.js
@@ -1,5 +1,7 @@
 export class Enemy {
-  constructor() {
+  constructor(damage = 10, persistent = false) {
     this.tag = 'enemy';
+    this.damage = damage;
+    this.persistent = persistent;
   }
 }

--- a/src/engine/components/Sprite.js
+++ b/src/engine/components/Sprite.js
@@ -1,6 +1,7 @@
 export class Sprite {
-  constructor(size = 20, color = 'white') {
+  constructor(size = 20, color = 'white', emoji = null) {
     this.size = size;
     this.color = color;
+    this.emoji = emoji;
   }
 }

--- a/src/engine/systems/CollisionSystem.js
+++ b/src/engine/systems/CollisionSystem.js
@@ -25,12 +25,25 @@ export class CollisionSystem {
         if (dist < bs.size / 2 + es.size / 2) {
           if (playerStats) playerStats.damageDone += bullet.get(Bullet).damage;
           this.game.removeEntity(bullet);
-          this.game.removeEntity(enemy);
-          const gem = new Entity()
-            .add(new Position(ep.x, ep.y))
-            .add(new Sprite(6, 'green'))
-            .add(new XPGem());
-          this.game.addEntity(gem);
+          if (enemy.has(Health)) {
+            const eh = enemy.get(Health);
+            eh.current -= bullet.get(Bullet).damage;
+            if (eh.current <= 0) {
+              this.game.removeEntity(enemy);
+              const gem = new Entity()
+                .add(new Position(ep.x, ep.y))
+                .add(new Sprite(6, 'green'))
+                .add(new XPGem());
+              this.game.addEntity(gem);
+            }
+          } else {
+            this.game.removeEntity(enemy);
+            const gem = new Entity()
+              .add(new Position(ep.x, ep.y))
+              .add(new Sprite(6, 'green'))
+              .add(new XPGem());
+            this.game.addEntity(gem);
+          }
           break;
         }
       }
@@ -45,7 +58,8 @@ export class CollisionSystem {
       const es = enemy.get(Sprite);
       const dist = Math.hypot(pp.x - ep.x, pp.y - ep.y);
       if (dist < ps.size / 2 + es.size / 2) {
-        const damage = 10;
+        const ec = enemy.get(Enemy);
+        const damage = ec.damage;
         if (player.has(Health)) {
           const health = player.get(Health);
           health.current -= damage;
@@ -54,7 +68,9 @@ export class CollisionSystem {
             if (this.game.onGameOver) this.game.onGameOver();
           }
         }
-        this.game.removeEntity(enemy);
+        if (!ec.persistent) {
+          this.game.removeEntity(enemy);
+        }
       }
     }
   }

--- a/src/engine/systems/EnemySpawnerSystem.js
+++ b/src/engine/systems/EnemySpawnerSystem.js
@@ -4,6 +4,9 @@ import { Velocity } from '../components/Velocity.js';
 import { Sprite } from '../components/Sprite.js';
 import { Enemy } from '../components/Enemy.js';
 import { PlayerControlled } from '../components/PlayerControlled.js';
+import { Health } from '../components/Health.js';
+
+const EMOJIS = ['👻', '👽', '😈', '💀', '🧟', '🤡', '👹', '👺'];
 
 export class EnemySpawnerSystem {
   constructor(interval = 2) {
@@ -12,37 +15,44 @@ export class EnemySpawnerSystem {
   }
   update(dt) {
     this.timer -= dt;
+    const spawnInterval = Math.max(0.5, this.interval - this.game.elapsed / 60);
     if (this.timer <= 0) {
-      this.timer = this.interval;
-      const canvas = this.game.ctx.canvas;
-      const side = Math.floor(Math.random() * 4);
-      let x, y;
-      if (side === 0) { // top
-        x = Math.random() * canvas.width;
-        y = -20;
-      } else if (side === 1) { // bottom
-        x = Math.random() * canvas.width;
-        y = canvas.height + 20;
-      } else if (side === 2) { // left
-        x = -20;
-        y = Math.random() * canvas.height;
-      } else { // right
-        x = canvas.width + 20;
-        y = Math.random() * canvas.height;
+      this.timer = spawnInterval;
+      const count = 1 + Math.floor(this.game.elapsed / 60);
+      for (let i = 0; i < count; i++) {
+        const canvas = this.game.ctx.canvas;
+        const side = Math.floor(Math.random() * 4);
+        let x, y;
+        if (side === 0) { // top
+          x = Math.random() * canvas.width;
+          y = -20;
+        } else if (side === 1) { // bottom
+          x = Math.random() * canvas.width;
+          y = canvas.height + 20;
+        } else if (side === 2) { // left
+          x = -20;
+          y = Math.random() * canvas.height;
+        } else { // right
+          x = canvas.width + 20;
+          y = Math.random() * canvas.height;
+        }
+        const player = [...this.game.entities].find(e => e.has(PlayerControlled) && e.has(Position));
+        if (!player) return;
+        const pp = player.get(Position);
+        const dx = pp.x - x;
+        const dy = pp.y - y;
+        const dist = Math.hypot(dx, dy) || 1;
+        const speed = 30 + Math.random() * 30;
+        const health = 1 + Math.floor(this.game.elapsed / 30);
+        const emoji = EMOJIS[Math.floor(Math.random() * EMOJIS.length)];
+        const enemy = new Entity()
+          .add(new Position(x, y))
+          .add(new Velocity((dx / dist) * speed, (dy / dist) * speed))
+          .add(new Sprite(30, null, emoji))
+          .add(new Enemy())
+          .add(new Health(health));
+        this.game.addEntity(enemy);
       }
-      const player = [...this.game.entities].find(e => e.has(PlayerControlled) && e.has(Position));
-      if (!player) return;
-      const pp = player.get(Position);
-      const dx = pp.x - x;
-      const dy = pp.y - y;
-      const dist = Math.hypot(dx, dy) || 1;
-      const speed = 30 + Math.random() * 30;
-      const enemy = new Entity()
-        .add(new Position(x, y))
-        .add(new Velocity((dx / dist) * speed, (dy / dist) * speed))
-        .add(new Sprite(20, 'red'))
-        .add(new Enemy());
-      this.game.addEntity(enemy);
     }
   }
 }

--- a/src/engine/systems/HUDSystem.js
+++ b/src/engine/systems/HUDSystem.js
@@ -1,4 +1,3 @@
-import { Health } from '../components/Health.js';
 import { Experience } from '../components/Experience.js';
 import { Stats } from '../components/Stats.js';
 import { PlayerControlled } from '../components/PlayerControlled.js';
@@ -9,12 +8,10 @@ export class HUDSystem {
   }
 
   update() {
-    const player = [...this.game.entities].find(e => e.has(PlayerControlled) && e.has(Health) && e.has(Experience));
+    const player = [...this.game.entities].find(e => e.has(PlayerControlled) && e.has(Experience));
     if (!player) return;
-    const health = player.get(Health);
     const exp = player.get(Experience);
     const stats = player.has(Stats) ? player.get(Stats) : null;
-    this.hud.health.style.width = `${(health.current / health.max) * 100}%`;
     this.hud.xp.style.width = `${(exp.xp / exp.nextLevelXp) * 100}%`;
     if (stats) {
       this.hud.stats.textContent = `Damage Done: ${stats.damageDone} Damage Taken: ${stats.damageTaken}`;

--- a/src/engine/systems/RenderSystem.js
+++ b/src/engine/systems/RenderSystem.js
@@ -1,5 +1,7 @@
 import { Position } from '../components/Position.js';
 import { Sprite } from '../components/Sprite.js';
+import { PlayerControlled } from '../components/PlayerControlled.js';
+import { Health } from '../components/Health.js';
 
 export class RenderSystem {
   update() {
@@ -9,8 +11,26 @@ export class RenderSystem {
       if (entity.has(Position) && entity.has(Sprite)) {
         const p = entity.get(Position);
         const s = entity.get(Sprite);
-        ctx.fillStyle = s.color;
-        ctx.fillRect(p.x - s.size / 2, p.y - s.size / 2, s.size, s.size);
+        if (s.emoji) {
+          ctx.font = `${s.size}px sans-serif`;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillText(s.emoji, p.x, p.y);
+        } else {
+          ctx.fillStyle = s.color;
+          ctx.fillRect(p.x - s.size / 2, p.y - s.size / 2, s.size, s.size);
+        }
+        if (entity.has(PlayerControlled) && entity.has(Health)) {
+          const h = entity.get(Health);
+          const barWidth = 40;
+          const barHeight = 5;
+          const x = p.x - barWidth / 2;
+          const y = p.y - s.size / 2 - 10;
+          ctx.fillStyle = 'red';
+          ctx.fillRect(x, y, barWidth, barHeight);
+          ctx.fillStyle = 'green';
+          ctx.fillRect(x, y, barWidth * (h.current / h.max), barHeight);
+        }
       }
     }
   }

--- a/src/engine/systems/StageSystem.js
+++ b/src/engine/systems/StageSystem.js
@@ -1,0 +1,69 @@
+import { Entity } from '../Entity.js';
+import { Enemy } from '../components/Enemy.js';
+import { Position } from '../components/Position.js';
+import { Velocity } from '../components/Velocity.js';
+import { Sprite } from '../components/Sprite.js';
+import { Health } from '../components/Health.js';
+import { PlayerControlled } from '../components/PlayerControlled.js';
+
+export class StageSystem {
+  constructor(duration = 900) {
+    this.duration = duration;
+    this.nextReaper = duration;
+    this.cleared = false;
+  }
+
+  setDuration(seconds) {
+    this.duration = seconds;
+    this.nextReaper = seconds;
+    this.cleared = false;
+  }
+
+  update() {
+    if (this.game.elapsed >= this.nextReaper) {
+      if (!this.cleared) {
+        for (const e of Array.from(this.game.entities)) {
+          if (e.has(Enemy)) this.game.removeEntity(e);
+        }
+        if (this.game.onStageComplete) this.game.onStageComplete();
+        this.cleared = true;
+      }
+      this.spawnReaper();
+      this.nextReaper += 60;
+    }
+  }
+
+  spawnReaper() {
+    const canvas = this.game.ctx.canvas;
+    const side = Math.floor(Math.random() * 4);
+    let x, y;
+    if (side === 0) { // top
+      x = Math.random() * canvas.width;
+      y = -40;
+    } else if (side === 1) { // bottom
+      x = Math.random() * canvas.width;
+      y = canvas.height + 40;
+    } else if (side === 2) { // left
+      x = -40;
+      y = Math.random() * canvas.height;
+    } else { // right
+      x = canvas.width + 40;
+      y = Math.random() * canvas.height;
+    }
+    const player = [...this.game.entities].find(e => e.has(PlayerControlled) && e.has(Position));
+    if (!player) return;
+    const pp = player.get(Position);
+    const dx = pp.x - x;
+    const dy = pp.y - y;
+    const dist = Math.hypot(dx, dy) || 1;
+    const speed = 60;
+    const reaper = new Entity()
+      .add(new Position(x, y))
+      .add(new Velocity((dx / dist) * speed, (dy / dist) * speed))
+      .add(new Sprite(40, null, '☠️'))
+      .add(new Enemy(40, true))
+      .add(new Health(100));
+    this.game.addEntity(reaper);
+  }
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -16,15 +16,21 @@ import { CollisionSystem } from './engine/systems/CollisionSystem.js';
 import { PickupSystem } from './engine/systems/PickupSystem.js';
 import { HUDSystem } from './engine/systems/HUDSystem.js';
 import { EnemyAISystem } from './engine/systems/EnemyAISystem.js';
+import { StageSystem } from './engine/systems/StageSystem.js';
 import { Input } from './input.js';
 
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
 const game = new Game(ctx);
 const input = new Input(canvas);
 
 const hud = {
-  health: document.getElementById('health-fill'),
   xp: document.getElementById('xp-fill'),
   stats: document.getElementById('stats'),
 };
@@ -32,6 +38,11 @@ const hud = {
 const startMenu = document.getElementById('start-menu');
 const startBtn = document.getElementById('start-btn');
 const levelMenu = document.getElementById('level-menu');
+const stageSelect = document.getElementById('stage-select');
+const coinsDisplay = document.getElementById('coins');
+
+let coins = parseInt(localStorage.getItem('coins') || '0');
+coinsDisplay.textContent = `Coins: ${coins}`;
 
 function shuffle(arr) {
   return arr.sort(() => Math.random() - 0.5);
@@ -61,6 +72,12 @@ function handleLevelUp(player) {
   });
 }
 
+game.onStageComplete = () => {
+  coins += 100;
+  coinsDisplay.textContent = `Coins: ${coins}`;
+  localStorage.setItem('coins', coins);
+};
+
 game.onGameOver = () => {
   startBtn.textContent = 'Restart';
   startMenu.classList.remove('hidden');
@@ -69,6 +86,8 @@ game.onGameOver = () => {
 
 // Systems order
 game.addSystem(new EnemyAISystem());
+const stageSystem = new StageSystem();
+game.addSystem(stageSystem);
 game.addSystem(new PlayerControlSystem(input));
 game.addSystem(new MovementSystem());
 game.addSystem(new BulletSystem());
@@ -81,7 +100,7 @@ game.addSystem(new RenderSystem());
 const player = new Entity()
   .add(new Position(canvas.width / 2, canvas.height / 2))
   .add(new Velocity())
-  .add(new Sprite(20, 'cyan'))
+  .add(new Sprite(30, null, '🧍'))
   .add(new PlayerControlled())
   .add(new Experience())
   .add(new Health(100))
@@ -93,6 +112,8 @@ startBtn.addEventListener('click', () => {
   if (startBtn.textContent === 'Restart') {
     window.location.reload();
   } else {
+    const duration = parseInt(stageSelect.value) * 60;
+    stageSystem.setDuration(duration);
     startMenu.classList.add('hidden');
     game.start();
   }


### PR DESCRIPTION
## Summary
- Scale enemy spawn rate and health, drawing enemies as spooky emojis
- Render player with emoji and on-canvas health bar, move XP bar to fullscreen HUD bottom
- Add stage system with selectable duration, coins reward, and escalating Reaper boss spawns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab69a19c188332a499b76fdea7524e