### PR TITLE
Fix enemy spawn interval redeclaration

### DIFF
--- a/src/engine/systems/EnemySpawnerSystem.js
+++ b/src/engine/systems/EnemySpawnerSystem.js
@@ -15,7 +15,6 @@ export class EnemySpawnerSystem {
   }
   update(dt) {
     this.timer -= dt;
-    const spawnInterval = Math.max(0.2, this.interval - this.game.elapsed / 120);
     const spawnInterval = Math.max(0.3, this.interval - this.game.elapsed / 90);
     if (this.timer <= 0) {
       this.timer = spawnInterval;

--- a/src/index.js
+++ b/src/index.js
@@ -182,7 +182,12 @@ function handleLevelUp(player) {
   options.forEach(ab => {
     const btn = document.createElement('button');
     btn.className = 'level-option';
-    btn.innerHTML = `<span class="icon">${ab.icon}</span><div class="info"><div class="name">${ab.name}</div><div class="desc">${ab.desc}</div></div>`;
+    btn.innerHTML = `
+      <span class="icon">${ab.icon}</span>
+      <div class="info">
+        <div class="name">${ab.name}</div>
+        <div class="desc">${ab.desc}</div>
+      </div>`;
     btn.onclick = () => {
       ab.apply(player);
       levelMenu.classList.add('hidden');


### PR DESCRIPTION
## Summary
- Correct enemy spawner to calculate spawn interval once, preventing syntax errors and allowing game start buttons to work

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab7683c3f48332bd43b8055b0fd764