### PR TITLE
Fix bullet boundary handling and render hidden objects

### DIFF
--- a/src/engine/systems/BulletSystem.js
+++ b/src/engine/systems/BulletSystem.js
@@ -9,12 +9,13 @@ export class BulletSystem {
         const p = entity.get(Position);
         b.life -= dt;
         const canvas = this.game.ctx.canvas;
+        const cam = this.game.camera || { x: 0, y: 0 };
         if (
           b.life <= 0 ||
-          p.x < -10 ||
-          p.y < -10 ||
-          p.x > canvas.width + 10 ||
-          p.y > canvas.height + 10
+          p.x < cam.x - 10 ||
+          p.y < cam.y - 10 ||
+          p.x > cam.x + canvas.width + 10 ||
+          p.y > cam.y + canvas.height + 10
         ) {
           this.game.removeEntity(entity);
         }

--- a/src/engine/systems/RenderSystem.js
+++ b/src/engine/systems/RenderSystem.js
@@ -14,11 +14,12 @@ export class RenderSystem {
     const cam = this.game.camera || { x: 0, y: 0 };
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
     for (const entity of this.game.entities) {
-      if (entity.has(Position) && entity.has(Sprite)) {
-        const p = entity.get(Position);
+      if (!entity.has(Position)) continue;
+      const p = entity.get(Position);
+      const x = p.x - cam.x;
+      const y = p.y - cam.y;
+      if (entity.has(Sprite)) {
         const s = entity.get(Sprite);
-        const x = p.x - cam.x;
-        const y = p.y - cam.y;
         if (s.emoji) {
           ctx.font = `${s.size}px sans-serif`;
           ctx.textAlign = 'center';
@@ -39,6 +40,11 @@ export class RenderSystem {
           ctx.fillStyle = 'green';
           ctx.fillRect(bx, by, barWidth * (h.current / h.max), barHeight);
         }
+      } else {
+        ctx.font = '20px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('🌲', x, y);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Allow bullets to travel anywhere relative to camera instead of the world origin so shots no longer vanish at map edges
- Render any position-only entities as a tree emoji to expose hidden obstacles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab78cac4008332aed53ecb34128627